### PR TITLE
58 account button in modal

### DIFF
--- a/components/modal/new_account.vue
+++ b/components/modal/new_account.vue
@@ -42,12 +42,17 @@ const onSubmit = async () => {
         position: parseInt(accountPosition.value),
       });
     } else {
-      await api.createAccount(token.value, {
-        name: accountName.value,
-        color: DEFAULT_COLOR,
-        currency: accountCurrency.value,
-        kind: accountKind.value,
-      });
+      const response = await api.createAccount(token.value, {
+      name: accountName.value,
+      color: DEFAULT_COLOR,
+      currency: accountCurrency.value,
+      kind: accountKind.value,
+    });
+
+
+const account = response?.data || response;
+
+emit('saved', account);
     }
 
     emit('saved');

--- a/components/modal/new_transaction.vue
+++ b/components/modal/new_transaction.vue
@@ -44,6 +44,17 @@ const modalTitle = computed(() => {
     return isEdit.value ? 'Редактировать расход' : 'Новый расход';
   }
 });
+const isShowModal = ref(false);
+const currentItem = ref(null);
+
+const openCreate = () => {
+  currentItem.value = null;
+  isShowModal.value = true;
+};
+const onSavedAccount = async () => {
+  isShowModal.value = false;
+  await loadAccounts();
+};
 
 const toggleAccountCallback = (account) => {
   // console.log('toggleAccountCallback', account);
@@ -215,7 +226,14 @@ const onSubmit = async () => {
               :ids='currentAccountIds'
             />
             <div v-if='isAccountEmpty' class='text-danger mt-1'>
-              Невозможно создать операцию без счета. Создайте счет
+              Невозможно создать операцию без счета.
+              <button
+                type="button"
+                class="btn btn-outline-danger btn-sm"
+                @click="openCreate"
+              >
+                Создать счет
+              </button>
             </div>
           </div>
           <div class='col'>
@@ -256,4 +274,10 @@ const onSubmit = async () => {
       </div>
     </form>
   </ModalBase>
+    <ModalNewAccount
+    v-if='isShowModal'
+    :item='currentItem'
+    @saved='onSavedAccount'
+    @close="isShowModal = false"
+  />
 </template>

--- a/components/modal/new_transaction.vue
+++ b/components/modal/new_transaction.vue
@@ -51,11 +51,15 @@ const openCreate = () => {
   currentItem.value = null;
   isShowModal.value = true;
 };
-const onSavedAccount = async () => {
-  isShowModal.value = false;
-  await loadAccounts();
-};
 
+const onSavedAccount = (account) => {
+  isShowModal.value = false;
+
+  if (account) {
+    currentAccount.value = account;
+    currentAccountIds.value = [account.id];
+  }
+};
 const toggleAccountCallback = (account) => {
   // console.log('toggleAccountCallback', account);
   if (account == null) return;
@@ -222,6 +226,7 @@ const onSubmit = async () => {
         <div class='row'>
           <div class='col'>
             <FormAccounts
+              :key="currentAccountIds.join('-')"
               @toggle-account='toggleAccountCallback'
               :ids='currentAccountIds'
             />


### PR DESCRIPTION
На блоке со списком счетов в модальном окне операций добавить кнопку создания счёта [#58](https://github.com/mybudget-ws/mybudget3/issues/58)

#58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create new accounts directly from the transaction creation modal without navigating away.
  * Added a quick "Create Account" button for streamlined account setup during transactions.

* **Bug Fixes**
  * Improved account data handling to ensure newly created accounts are properly captured and reflected in forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->