### PR TITLE
Add transaction kinds to api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -88,12 +88,24 @@ const api = {
   // ---------------------
   // Transactions
   // ---------------------
+  // Возможные параметры для filters.kind: ['INCOME', 'EXPENSE', 'TRANSFER']
+  // можно перадть пустой массив, тогда будут все операции (без фильтрации),
+  // а можно передать и любую комбинацию:
+  //
+  // 1. Только доходы - filters.kind: ['INCOME']
+  // 2. Только расходы - filters.kind: ['EXPENSE']
+  // 3. Только переводы - filters.kind: ['TRANSFER']
+  // 4. Можно передать несколько разных вариантов, например для доходов
+  //    и расходов будет - filters.kind: ['INCOME', 'EXPENSE'] и т.д.
   async transactions(token, { page, perPage, filters }) {
     const query = `
       query(
         $page:Int, $perPage:Int,
-        $accountIds:[Int!], $categoryIds:[Int!],
-        $projectIds:[Int!], $propertyIds:[Int!]
+        $accountIds:[Int!],
+        $categoryIds:[Int!],
+        $projectIds:[Int!],
+        $propertyIds:[Int!],
+        $kinds:[TransactionKind!]
       ) {
         items:transactions(
           page: $page,
@@ -101,7 +113,8 @@ const api = {
           accountIds: $accountIds,
           categoryIds: $categoryIds,
           projectIds: $projectIds,
-          propertyIds: $propertyIds
+          propertyIds: $propertyIds,
+          kinds: $kinds,
         ) {
           id
           amount
@@ -115,8 +128,8 @@ const api = {
         }
       }
     `;
-    const { accountIds, categoryIds, projectIds, propertyIds } = filters;
-    const vars = { page, perPage, accountIds, categoryIds, projectIds, propertyIds };
+    const { accountIds, categoryIds, projectIds, propertyIds, kinds } = filters;
+    const vars = { page, perPage, accountIds, categoryIds, projectIds, propertyIds, kinds };
     const data = await client(token).request(query, vars);
     log('transactions', data);
     return data.items;

--- a/lib/api.js
+++ b/lib/api.js
@@ -88,15 +88,15 @@ const api = {
   // ---------------------
   // Transactions
   // ---------------------
-  // Возможные параметры для filters.kind: ['INCOME', 'EXPENSE', 'TRANSFER']
+  // Возможные параметры для filters.kinds: ['INCOME', 'EXPENSE', 'TRANSFER']
   // можно перадть пустой массив, тогда будут все операции (без фильтрации),
   // а можно передать и любую комбинацию:
   //
-  // 1. Только доходы - filters.kind: ['INCOME']
-  // 2. Только расходы - filters.kind: ['EXPENSE']
-  // 3. Только переводы - filters.kind: ['TRANSFER']
+  // 1. Только доходы - filters.kinds: ['INCOME']
+  // 2. Только расходы - filters.kinds: ['EXPENSE']
+  // 3. Только переводы - filters.kinds: ['TRANSFER']
   // 4. Можно передать несколько разных вариантов, например для доходов
-  //    и расходов будет - filters.kind: ['INCOME', 'EXPENSE'] и т.д.
+  //    и расходов будет - filters.kinds: ['INCOME', 'EXPENSE'] и т.д.
   async transactions(token, { page, perPage, filters }) {
     const query = `
       query(


### PR DESCRIPTION
https://agileseason.com/#/boards/42/issues/8621/number/102

#102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The transactions API now supports an optional kind filter, enabling users to refine transaction queries by specific types. Users can omit the filter to retrieve all transactions or specify one or more kinds to retrieve only transactions matching those types, providing more granular control and flexibility over API query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->