### PR TITLE
Add initial account id in new_transfer_modal

### DIFF
--- a/components/dashboard.vue
+++ b/components/dashboard.vue
@@ -23,6 +23,7 @@ const isShowModalTransfer = ref(false);
 const currentKind = ref(KIND_INCOME);
 const isCopyItem = ref(false);
 const currentItem = ref(null);
+const selectedTransferAccountId = ref(null);
 
 const openCreate = (kind) => {
   currentItem.value = null;
@@ -31,7 +32,8 @@ const openCreate = (kind) => {
   isShowModal.value = true;
 };
 
-const openCreateTransfer = () => {
+const openCreateTransfer = (accountId = NaN) => {
+  selectedTransferAccountId.value = accountId;
   isShowModalTransfer.value = true;
 };
 
@@ -96,6 +98,7 @@ watch(token, (val) => {
 
   <ModalNewTransfer
     v-if="isShowModalTransfer"
+    :initial-account-id="selectedTransferAccountId"
     @saved="onSaved"
     @close="closeModals"
   />
@@ -123,7 +126,7 @@ watch(token, (val) => {
         <button
           class='btn btn-outline-secondary'
           type='button'
-          @click='openCreateTransfer'
+          @click='openCreateTransfer()'
         >
           <IconArrowsRightLeft stroke-width=2 />
         </button>
@@ -270,7 +273,7 @@ watch(token, (val) => {
                     v-tooltip:bottom="'Создать перевод'"
                     type='button'
                     class='btn btn-action'
-                    @click='openCreateTransfer'
+                    @click='openCreateTransfer(item.id)'
                   >
                     <IconArrowsRightLeft size=18 stroke-width=1 />
                   </button>

--- a/components/form/accounts.vue
+++ b/components/form/accounts.vue
@@ -32,6 +32,9 @@ const props = defineProps({
     type: Array,
     default: [],
   },
+  initialSelectedId: {
+    type: Number,
+  },
 });
 
 const load = async () => {
@@ -53,7 +56,9 @@ const load = async () => {
 };
 
 const initSelectedIds = (query = route.query) => {
-  if (props.ids.length === 0) {
+  if (props.initialSelectedId) {
+    selectedIds.value = [props.initialSelectedId];
+  } else if (props.ids.length === 0) {
     const queryIds = query.accounts?.toString().split(',').filter(v => v !== '') || [];
     selectedIds.value = queryIds.map(id => Number(id)).filter(id => id > 0);
   } else {

--- a/components/modal/new_transfer.vue
+++ b/components/modal/new_transfer.vue
@@ -1,8 +1,4 @@
 <script setup>
-import {
-  IconAlertTriangle,
-} from '@tabler/icons-vue';
-
 import api from '~/lib/api';
 
 const { token } = useAuth();
@@ -19,6 +15,12 @@ const amountFromRef = ref(null);
 const amountFromError = ref('');
 const amountToError = ref('');
 const sameAccountError = ref('');
+
+const props = defineProps({
+  initialAccountId: {
+    type: Number,
+  },
+});
 
 const emit = defineEmits(['saved', 'close', 'accountNew']);
 
@@ -125,6 +127,7 @@ watch(amountFrom, (newValue) => {
             <FormAccounts
               label='Откуда'
               radioGroupName='accountFrom'
+              :initialSelectedId='props.initialAccountId'
               @toggle-account='toggleAccountFromCallback'
               @loaded="isLoaded = true"
             />


### PR DESCRIPTION
https://agileseason.com/#/boards/42/issues/8639/number/114

#114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer modal now supports pre-selecting an account when initiated from an account row. Opening the transfer flow from a specific account automatically selects that account as the source, streamlining the transfer creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->