### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
       - master
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/mybudget-ws/mybudget3/security/code-scanning/1](https://github.com/mybudget-ws/mybudget3/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job so its `GITHUB_TOKEN` is constrained to least privilege.  
For this workflow, the safest minimal change is:

- In `.github/workflows/deploy.yml`, under `jobs.build`, add:
  - `permissions:`
  - `contents: read`

This preserves existing behavior (`actions/checkout` needs contents read access) and does not interfere with the already-correct `deploy` job permissions (`pages: write`, `id-token: write`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->